### PR TITLE
Allow Multi-deposits in single Txid

### DIFF
--- a/Cryptocurrency-crypto-bot.sql
+++ b/Cryptocurrency-crypto-bot.sql
@@ -45,7 +45,7 @@ CREATE TABLE `deposits` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `address` varchar(60) NOT NULL,
   `amount` decimal(32,8) NOT NULL,
-  `txid` varchar(64) NOT NULL,
+  `txid` varchar(125) NOT NULL,
   `confirmations` int(11) NOT NULL,
   `credited` tinyint(1) unsigned NOT NULL,
   `datetime` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/README.md
+++ b/README.md
@@ -76,3 +76,4 @@ walletnotify=/path/to/your/bot/folder/transaction.sh %s
 ## Projects using the bot - Feel free to contact me to get added
 - Limitless (VIP) - Discord: https://discord.gg/wtz6QYX - Website: http://vip.limitlessvip.co.za/
 - BARE Coin (BARE) - Discord: https://discord.gg/xmQbzNH - Website: https://bare.network/
+- Coin Pool Services - Discord: https://discord.gg/eWB5z2E - Website: https://coinpoolservices.com/

--- a/functions/command.js
+++ b/functions/command.js
@@ -791,7 +791,7 @@ module.exports = {
                 var deposit_category = latestDeposits[i].category;
                 var deposit_amount = Big(latestDeposits[i].amount).toString();
                 var deposit_confirmations = latestDeposits[i].confirmations;
-                var deposit_txid = latestDeposits[i].txid;
+                var deposit_txid = latestDeposits[i].txid + ' ' + deposit_address;
                 var deposit_generated = latestDeposits[i].generated; // Check if its a stake so not use it
                 if(deposit_category === 'receive' && !deposit_generated && deposit_confirmations < config.wallet.minConfirmationsDeposit){
                     var creditDeposit = await transaction.transaction_add_update_deposits_on_db(deposit_address,Big(deposit_amount).toString(),deposit_confirmations,deposit_txid);


### PR DESCRIPTION
- Issue came to light when shared Masternode services where doing payouts in single Txid and more than one user was using their bot address as the receiving address.

- Since we need to keep the txid field as unique so the user doesnt get credited for the same Txid more than once we can just put the receiving users address on the end of the txid to keep it still unique to the user.