### PR TITLE
Add an option to allow the bot to respond in any server

### DIFF
--- a/config.js
+++ b/config.js
@@ -14,6 +14,7 @@ module.exports = {
         "moderatorIDs": [ "XXX" ], // This discrod user IDs are able to use moderator commands and bypass cooldowns
         "vipGroupName": "Dev Team", // Users of this group are able to use vip commands and bypass cooldowns
         "respondChannelIDs": [ "XXX" ], // Discord server channel IDs the bot does listen to
+        "allowAllChannels": false, // If enabled the bot will be able to reply in all channels making it essentially a public bot
         "commandIgnor": ["battle","cversion","destroy","gift","kill","lock","me","rez","top","use","me","cstart","cstop","cstart","jackpot","summary","shop","activate","mention","claim"], // commands to ignor because of other bots
         "stakePoolChannelID": "XXX", // If staking is configured use this channel to broadcast stake pool payouts
         "allowDM": true, // Allow or disable direct messages for commands to the bot with true or false

--- a/functions/check.js
+++ b/functions/check.js
@@ -13,6 +13,7 @@ try{
 
 const Big = require('big.js'); // https://github.com/MikeMcl/big.js -> http://mikemcl.github.io/big.js/
 const rp = require('request-promise');
+const { bot } = require('../config');
 
 /* ------------------------------------------------------------------------------ */
 // // // // // // // // // // // // // // // // // // // // // // // // // // // //
@@ -116,14 +117,17 @@ module.exports = {
      },
 
     /* ------------------------------------------------------------------------------ */
-    // Check if the channel is a valid channel to repond to
+    // Check if the channel is a valid channel to respond to or if open to all channels
     /* ------------------------------------------------------------------------------ */
-
     check_respond_channel: function(channelID){
-        var respondChannelIDs = {};
-        for (var i = 0 ; i < config.bot.respondChannelIDs.length ; ++i)
-        respondChannelIDs[config.bot.respondChannelIDs[i]] = true;
-        return respondChannelIDs[channelID];
+        if (config.bot.allowAllChannels == true) {
+            return;
+        } else if(config.bot.allowAllChannels == false) {
+            var respondChannelIDs = {};
+            for (var i = 0 ; i < config.bot.respondChannelIDs.length ; ++i)
+            respondChannelIDs[config.bot.respondChannelIDs[i]] = true;
+            return respondChannelIDs[channelID];
+        }
     },
 
     /* ------------------------------------------------------------------------------ */

--- a/index.js
+++ b/index.js
@@ -119,8 +119,11 @@ if(messageContent.startsWith(config.bot.commandPrefix)){
     }
 
     // If its not a dm message check if its a valid channel for commands
-    if(!check.check_respond_channel(channelID) && messageType !== 'dm')
-      return;
+    if(config.bot.allowAllChannels == "true")
+        return;
+    else if(config.bot.allowAllChannels == false)
+        if(!check.check_respond_channel(channelID) && messageType !== 'dm')
+        return;
 
     // Check if admin mode is enabled and only allow commands from admins
     if(config.bot.adminMode && userRole != 3){


### PR DESCRIPTION
This allows the admin to make it so the bot can be invited into any server without needing to add the channel ids to the array. Practically making this a public bot that anyone can invite if the admin wants.